### PR TITLE
Fail when launching an RC without the rc.host property set.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -51,6 +51,7 @@
   </target>
 
   <target name="launch-remote-control-with-custom-profile" depends="check-for-custom-profile" if="use.custom.profile">
+    <fail unless="rc.host" message="Property rc.host must be set in ${env.HOSTNAME}.project.properties" /> 
     <java classpathref="remote-control.classpath"
           classname="com.thoughtworks.selenium.grid.remotecontrol.SelfRegisteringRemoteControlLauncher"
           fork="true"


### PR DESCRIPTION
This will prevent launching an RC with a host of ${rc.host} with a more useful message.
