### PR TITLE
Disabling all JIT preferences in the certificateExceptions custom profile

### DIFF
--- a/firefoxprofiles/certificateExceptions/prefs.js
+++ b/firefoxprofiles/certificateExceptions/prefs.js
@@ -1,0 +1,7 @@
+user_pref("javascript.options.jitprofiling.chrome", false);
+user_pref("javascript.options.jitprofiling.content", false);
+user_pref("javascript.options.methodjit.chrome", false);
+user_pref("javascript.options.methodjit.content", false);
+user_pref("javascript.options.methodjit_always", false);
+user_pref("javascript.options.tracejit.chrome", false);
+user_pref("javascript.options.tracejit.content", false);


### PR DESCRIPTION
Disabling all JIT preferences in the certificateExceptions custom profile.
