### PR TITLE
Set the pref via prefs.js to disable Telemetry, by setting .enabled to false.

### DIFF
--- a/firefoxprofiles/certificateExceptions/prefs.js
+++ b/firefoxprofiles/certificateExceptions/prefs.js
@@ -5,3 +5,4 @@ user_pref("javascript.options.methodjit.content", false);
 user_pref("javascript.options.methodjit_always", false);
 user_pref("javascript.options.tracejit.chrome", false);
 user_pref("javascript.options.tracejit.content", false);
+user_pref("toolkit.telemetry.enabled", false);


### PR DESCRIPTION
Set the pref via prefs.js to disable Telemetry, by setting .enabled to false

Not sure if we need "toolkit.telemetry.prompted" to be added with
"true", but I don't think so.
