### PR TITLE
Change default launch target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,4 +1,4 @@
-<project name="selenium-grid" default="launch-remote-control" basedir=".">
+<project name="selenium-grid" default="launch-node" basedir=".">
 
   <property environment="env"/>
   <exec executable="hostname" osfamily="unix" failifexecutionfails="false" outputproperty="env.COMPUTERNAME"/>


### PR DESCRIPTION
Change default launch target to launch-node because launch-remote-control no longer exists.
