### PR TITLE
Adding Firefox 24,27 and 28 for SCL3 Windows nodes

### DIFF
--- a/win7.json
+++ b/win7.json
@@ -4,21 +4,21 @@
            {
                 "browserName": "firefox",
                 "version": "24",
-                "firefox_binary": "C:/Program Files/Mozilla Firefox 24/firefox.exe",
+                "firefox_binary": "C:/Program Files (x86)/Mozilla Firefox 24/firefox.exe",
                 "platform": "WINDOWS",
                 "maxInstances": 1,
                 "seleniumProtocol": "WebDriver"
             }, {
                 "browserName": "firefox",
                 "version": "27",
-                "firefox_binary": "C:/Program Files/Mozilla Firefox 27/firefox.exe",
+                "firefox_binary": "C:/Program Files (x86)/Mozilla Firefox 27/firefox.exe",
                 "platform": "WINDOWS",
                 "maxInstances": 1,
                 "seleniumProtocol": "WebDriver"
             }, {
                 "browserName": "firefox",
                 "version": "28",
-                "firefox_binary": "C:/Program Files/Mozilla Firefox 28/firefox.exe",
+                "firefox_binary": "C:/Program Files (x86)/Mozilla Firefox 28/firefox.exe",
                 "platform": "WINDOWS",
                 "maxInstances": 1,
                 "seleniumProtocol": "WebDriver"


### PR DESCRIPTION
I've installed Firefox versions 24, 27 and 28 on our SCL3 nodes. This win7.json file will completely replace the win7.json we use on our VMWare instances.  I'll take down all the VMWare instances after this is merged and configure all our Windows nodes to run in SCL3
