### PR TITLE
Remove Opera and Aurora from MacOS nodes

### DIFF
--- a/mac.json
+++ b/mac.json
@@ -22,18 +22,6 @@
                 "platform": "MAC",
                 "maxInstances": 1,
                 "seleniumProtocol": "WebDriver"
-            }, {
-                "browserName": "firefox",
-                "version": "aurora",
-                "firefox_binary": "/Applications/FirefoxAurora.app/Contents/MacOS/firefox-bin",
-                "platform": "MAC",
-                "maxInstances": 1,
-                "seleniumProtocol": "WebDriver"
-            }, {
-                "browserName": "opera",
-                "platform": "MAC",
-                "maxInstances": 1,
-                "seleniumProtocol": "WebDriver"
             }
         ],
     "configuration": {}


### PR DESCRIPTION
This pull request removes Opera and Aurora from our Mac nodes.
