### PR TITLE
Add support for a staging Selenium hub instance

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -35,35 +35,18 @@
   </target>
 
   <target name="set-hosts">
-    <!-- nodes that can't be addressed by hostname -->
-    <condition property="isNotAddressable">
-      <matches pattern="${nonaddressable.hostnames.regex}"
-               string="${env.HOSTNAME}"
-               casesensitive="false"/>
-    </condition>
-
-    <!-- production nodes -->
-    <condition property="isProduction">
-      <matches pattern="${production.hostnames.regex}"
-               string="${env.HOSTNAME}"
-               casesensitive="false"/>
-    </condition>
-
-    <!-- if this is a production node set the production hub host -->
+    <!-- set the production hub host for the production environment -->
     <condition property="hub.host" value="${production.hub.host}">
-      <isset property="isProduction"/>
+      <matches pattern="^production$" string="${env}"/>
+    </condition>
+
+    <!-- set the staging hub host for the staging environment -->
+    <condition property="hub.host" value="${staging.hub.host}">
+      <matches pattern="^staging$" string="${env}"/>
     </condition>
 
     <!-- otherwise set to localhost (unless overridden) -->
     <property name="hub.host" value="localhost"/>
-
-    <!-- if this is a production node that can't be addressed then use IP -->
-    <condition property="node.host" value="IP">
-      <and>
-        <isset property="isProduction"/>
-        <isset property="isNotAddressable"/>
-      </and>
-    </condition>
 
     <!-- if the hub is running on localhost then so must the node be -->
     <condition property="node.host" value="localhost">

--- a/default.properties
+++ b/default.properties
@@ -1,6 +1,5 @@
 selenium.version.major = 2.46
 selenium.version.minor = 0
-production.hostnames.regex = (qa|selenium)\-*[0-9]*(\.qa\.mtv2\.mozilla\.com|\-\w+)
-nonaddressable.hostnames.regex = qa[0-9]*\-\w+
 production.hub.host = selenium-hub1.qa.scl3.mozilla.com
+staging.hub.host = selenium-hub-staging1.qa.scl3.mozilla.com
 hub.port = 4444


### PR DESCRIPTION
This allows us to easily switch between our production and staging instances by adding an 'env' property. It can be set using `-Denv=staging` for example. I've also removed the non-addressable host support as all of our hosts are now addressable (it was an issue when running Windows VMs from the Mac Minis). If a node is still not addressable, it can be fixed by appending `-Dnode.host=IP` to the command line when starting the node.

I'd like to land this soon because it makes upgrading to 2.47.1 much easier. Normally I'd ask for review from @bobsilverberg but he's PTO for the next few weeks. @m8ttyB would you be comfortable reviewing this for me?