### PR TITLE
Avoid system proxy when connecting to the hub

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -111,6 +111,8 @@
           classname="org.openqa.grid.selenium.GridLauncher"
           fork="true"
           failonerror="true">
+      <sysproperty key="http.nonProxyHosts"
+                   value="${hub.host}"/>
       <arg value="-role"/>
       <arg value="node"/>
       <arg value="-id"/>
@@ -131,6 +133,8 @@
           classname="org.openqa.grid.selenium.GridLauncher"
           fork="true"
           failonerror="true">
+      <sysproperty key="http.nonProxyHosts"
+                   value="${hub.host}"/>
       <arg value="-role"/>
       <arg value="node"/>
       <arg value="-id"/>


### PR DESCRIPTION
This is needed for the new Mac Minis, which have a necessary system proxy defined. We need to avoid using the proxy when attempting to communicate between the node and the hub.

Pinging @bobsilverberg for review.