### PR TITLE
Upgrade to latest Firefox and Selenium versions

### DIFF
--- a/default.properties
+++ b/default.properties
@@ -1,5 +1,5 @@
-selenium.version.major = 2.47
-selenium.version.minor = 1
+selenium.version.major = 2.48
+selenium.version.minor = 2
 production.hub.host = selenium-hub1.qa.scl3.mozilla.com
 staging.hub.host = selenium-hub-staging1.qa.scl3.mozilla.com
 hub.port = 4444

--- a/mac.json
+++ b/mac.json
@@ -3,13 +3,6 @@
         [
             {
                 "browserName": "firefox",
-                "version": "37",
-                "firefox_binary": "/Applications/Firefox 37.app/Contents/MacOS/firefox-bin",
-                "platform": "MAC",
-                "maxInstances": 1,
-                "seleniumProtocol": "WebDriver"
-            }, {
-                "browserName": "firefox",
                 "version": "38",
                 "firefox_binary": "/Applications/Firefox 38.app/Contents/MacOS/firefox-bin",
                 "platform": "MAC",
@@ -19,6 +12,13 @@
                 "browserName": "firefox",
                 "version": "39",
                 "firefox_binary": "/Applications/Firefox 39.app/Contents/MacOS/firefox-bin",
+                "platform": "MAC",
+                "maxInstances": 1,
+                "seleniumProtocol": "WebDriver"
+            }, {
+                "browserName": "firefox",
+                "version": "40",
+                "firefox_binary": "/Applications/Firefox 40.app/Contents/MacOS/firefox-bin",
                 "platform": "MAC",
                 "maxInstances": 1,
                 "seleniumProtocol": "WebDriver"

--- a/mac.json
+++ b/mac.json
@@ -3,15 +3,15 @@
         [
             {
                 "browserName": "firefox",
-                "version": "40",
-                "firefox_binary": "/Applications/Firefox 40.app/Contents/MacOS/firefox-bin",
+                "version": "41",
+                "firefox_binary": "/Applications/Firefox 41.app/Contents/MacOS/firefox-bin",
                 "platform": "MAC",
                 "maxInstances": 1,
                 "seleniumProtocol": "WebDriver"
             }, {
                 "browserName": "firefox",
-                "version": "41",
-                "firefox_binary": "/Applications/Firefox 41.app/Contents/MacOS/firefox-bin",
+                "version": "42",
+                "firefox_binary": "/Applications/Firefox 42.app/Contents/MacOS/firefox-bin",
                 "platform": "MAC",
                 "maxInstances": 1,
                 "seleniumProtocol": "WebDriver"

--- a/mac.json
+++ b/mac.json
@@ -3,22 +3,15 @@
         [
             {
                 "browserName": "firefox",
-                "version": "38",
-                "firefox_binary": "/Applications/Firefox 38.app/Contents/MacOS/firefox-bin",
-                "platform": "MAC",
-                "maxInstances": 1,
-                "seleniumProtocol": "WebDriver"
-            }, {
-                "browserName": "firefox",
-                "version": "39",
-                "firefox_binary": "/Applications/Firefox 39.app/Contents/MacOS/firefox-bin",
-                "platform": "MAC",
-                "maxInstances": 1,
-                "seleniumProtocol": "WebDriver"
-            }, {
-                "browserName": "firefox",
                 "version": "40",
                 "firefox_binary": "/Applications/Firefox 40.app/Contents/MacOS/firefox-bin",
+                "platform": "MAC",
+                "maxInstances": 1,
+                "seleniumProtocol": "WebDriver"
+            }, {
+                "browserName": "firefox",
+                "version": "41",
+                "firefox_binary": "/Applications/Firefox 41.app/Contents/MacOS/firefox-bin",
                 "platform": "MAC",
                 "maxInstances": 1,
                 "seleniumProtocol": "WebDriver"

--- a/win7.json
+++ b/win7.json
@@ -3,22 +3,15 @@
         [
            {
                 "browserName": "firefox",
-                "version": "38",
-                "firefox_binary": "C:/Program Files (x86)/Mozilla Firefox 38/firefox.exe",
-                "platform": "WINDOWS",
-                "maxInstances": 1,
-                "seleniumProtocol": "WebDriver"
-            }, {
-                "browserName": "firefox",
-                "version": "39",
-                "firefox_binary": "C:/Program Files (x86)/Mozilla Firefox 39/firefox.exe",
-                "platform": "WINDOWS",
-                "maxInstances": 1,
-                "seleniumProtocol": "WebDriver"
-            }, {
-                "browserName": "firefox",
                 "version": "40",
                 "firefox_binary": "C:/Program Files (x86)/Mozilla Firefox 40/firefox.exe",
+                "platform": "WINDOWS",
+                "maxInstances": 1,
+                "seleniumProtocol": "WebDriver"
+            }, {
+                "browserName": "firefox",
+                "version": "41",
+                "firefox_binary": "C:/Program Files (x86)/Mozilla Firefox 41/firefox.exe",
                 "platform": "WINDOWS",
                 "maxInstances": 1,
                 "seleniumProtocol": "WebDriver"

--- a/win7.json
+++ b/win7.json
@@ -3,13 +3,6 @@
         [
            {
                 "browserName": "firefox",
-                "version": "37",
-                "firefox_binary": "C:/Program Files (x86)/Mozilla Firefox 37/firefox.exe",
-                "platform": "WINDOWS",
-                "maxInstances": 1,
-                "seleniumProtocol": "WebDriver"
-            }, {
-                "browserName": "firefox",
                 "version": "38",
                 "firefox_binary": "C:/Program Files (x86)/Mozilla Firefox 38/firefox.exe",
                 "platform": "WINDOWS",
@@ -19,6 +12,13 @@
                 "browserName": "firefox",
                 "version": "39",
                 "firefox_binary": "C:/Program Files (x86)/Mozilla Firefox 39/firefox.exe",
+                "platform": "WINDOWS",
+                "maxInstances": 1,
+                "seleniumProtocol": "WebDriver"
+            }, {
+                "browserName": "firefox",
+                "version": "40",
+                "firefox_binary": "C:/Program Files (x86)/Mozilla Firefox 40/firefox.exe",
                 "platform": "WINDOWS",
                 "maxInstances": 1,
                 "seleniumProtocol": "WebDriver"

--- a/win7.json
+++ b/win7.json
@@ -3,15 +3,15 @@
         [
            {
                 "browserName": "firefox",
-                "version": "40",
-                "firefox_binary": "C:/Program Files (x86)/Mozilla Firefox 40/firefox.exe",
+                "version": "41",
+                "firefox_binary": "C:/Program Files (x86)/Mozilla Firefox 41/firefox.exe",
                 "platform": "WINDOWS",
                 "maxInstances": 1,
                 "seleniumProtocol": "WebDriver"
             }, {
                 "browserName": "firefox",
-                "version": "41",
-                "firefox_binary": "C:/Program Files (x86)/Mozilla Firefox 41/firefox.exe",
+                "version": "42",
+                "firefox_binary": "C:/Program Files (x86)/Mozilla Firefox 42/firefox.exe",
                 "platform": "WINDOWS",
                 "maxInstances": 1,
                 "seleniumProtocol": "WebDriver"


### PR DESCRIPTION
Drop Firefox versions to latest and previous, seeing as we only really ever use one version anyway.